### PR TITLE
`Btc::ImportAddressJob` retries if fails

### DIFF
--- a/app/jobs/btc/import_address_job.rb
+++ b/app/jobs/btc/import_address_job.rb
@@ -1,6 +1,8 @@
 module Btc
   class ImportAddressJob < ApplicationJob
 
+    sidekiq_options retry: true
+
     def perform(public_address)
       ImportAddress.(public_address)
     end

--- a/spec/jobs/btc/import_address_job_spec.rb
+++ b/spec/jobs/btc/import_address_job_spec.rb
@@ -7,6 +7,8 @@ module Btc
       expect(described_class < ApplicationJob).to be true
     end
 
+    it { is_expected.to be_retryable(true) }
+
     it "delegates work to #{Btc::ImportAddress}" do
       expect(Btc::ImportAddress).to receive(:call).with("abc")
       described_class.new.perform("abc")


### PR DESCRIPTION
If job is run more than once, re-importing (since we're not reindexing anyway) is not a problem and is desirable. However, if a tx occurs before it is reimported again, bitcoind will need to be re-indexed. This should be managed another way.