### PR TITLE
Fix the confirmation computation of ether blocks

### DIFF
--- a/app/services/eth/save_block_info.rb
+++ b/app/services/eth/save_block_info.rb
@@ -11,7 +11,7 @@ module Eth
         first_or_initialize
 
       height = remote_block["number"].to_i(16)
-      confirmations = c.current_block_number - height
+      confirmations = c.current_block_number - height + 1
 
       block.update_attributes!(
         height: height,

--- a/spec/services/eth/save_block_info_spec.rb
+++ b/spec/services/eth/save_block_info_spec.rb
@@ -32,7 +32,7 @@ module Eth
           current_block_number: current_block_number,
         ).block
         expect(block).to eq block_eth
-        expect(block.confirmations).to eq 10
+        expect(block.confirmations).to eq 11
         expect(block.block_hash).to eq "abc"
       end
     end
@@ -45,7 +45,7 @@ module Eth
         ).block
         expect(block).to be_eth
         expect(block.block_hash).to eq "abc"
-        expect(block.confirmations).to eq 10
+        expect(block.confirmations).to eq 11
         expect(block.height).to eq 1292030
       end
     end


### PR DESCRIPTION
If current block is 200, and the block we're syncing is 200, we have 1 confirmation