### PR TITLE
Delete forked blocks

### DIFF
--- a/app/services/btc/delete_forked_block.rb
+++ b/app/services/btc/delete_forked_block.rb
@@ -1,0 +1,16 @@
+module Btc
+  class DeleteForkedBlock
+
+    extend LightService::Action
+    expects :remote_block
+
+    executed do |c|
+      height = c.remote_block["height"]
+      block_hash = c.remote_block["hash"]
+      forked_blocks = Block.btc.where(height: height).
+        where.not(block_hash: block_hash)
+      forked_blocks.destroy_all
+    end
+
+  end
+end

--- a/app/services/eth/delete_forked_block.rb
+++ b/app/services/eth/delete_forked_block.rb
@@ -1,0 +1,16 @@
+module Eth
+  class DeleteForkedBlock
+
+    extend LightService::Action
+    expects :remote_block
+
+    executed do |c|
+      height = c.remote_block["number"].to_i(16)
+      block_hash = c.remote_block["hash"]
+      forked_blocks = Block.eth.where(height: height).
+        where.not(block_hash: block_hash)
+      forked_blocks.destroy_all
+    end
+
+  end
+end

--- a/app/services/eth/sync_block.rb
+++ b/app/services/eth/sync_block.rb
@@ -12,6 +12,7 @@ module Eth
         InitEthereumClient,
         GetCurrentBlock,
         GetRemoteBlock,
+        DeleteForkedBlock,
         SaveBlockInfo,
         GetRemoteTxs,
         iterate(:remote_txs, [

--- a/spec/services/btc/delete_forked_block_spec.rb
+++ b/spec/services/btc/delete_forked_block_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+module Btc
+  RSpec.describe DeleteForkedBlock do
+
+    let(:remote_block) { { "height" => 210, "hash" => "abd" } }
+
+    context "local block with block_height exists whose hash does not match the remote_block" do
+      let!(:block_btc) do
+        create(:block, height: 210, coin: "btc", block_hash: "abc")
+      end
+      let!(:block_eth) do
+        create(:block, height: 210, coin: "eth", block_hash: "abc")
+      end
+
+      it "deletes the local block" do
+        described_class.execute(remote_block: remote_block)
+        expect(Block.eth.find_by(block_hash: "abc")).to be_present
+        expect(Block.btc.find_by(block_hash: "abc")).to be_nil
+      end
+    end
+
+    context "local block with block_hash exists and it matches the remote_block" do
+      let!(:block_btc) do
+        create(:block, height: 210, coin: "btc", block_hash: "abd")
+      end
+      let!(:block_eth) do
+        create(:block, height: 210, coin: "eth", block_hash: "abd")
+      end
+
+      it "does nothing" do
+        described_class.execute(remote_block: remote_block)
+        expect(Block.eth.find_by(block_hash: "abd")).to be_present
+        expect(Block.btc.find_by(block_hash: "abd")).to be_present
+      end
+    end
+
+  end
+end

--- a/spec/services/eth/delete_forked_block_spec.rb
+++ b/spec/services/eth/delete_forked_block_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+module Eth
+  RSpec.describe DeleteForkedBlock do
+
+    let(:remote_block) do
+      { "number" => "0x#{210.to_s(16)}", "hash" => "abd" }
+    end
+
+    context "local block with block_height exists whose hash does not match the remote_block" do
+      let!(:block_btc) do
+        create(:block, height: 210, coin: "btc", block_hash: "abc")
+      end
+      let!(:block_eth) do
+        create(:block, height: 210, coin: "eth", block_hash: "abc")
+      end
+
+      it "deletes the local block" do
+        described_class.execute(remote_block: remote_block)
+        expect(Block.eth.find_by(block_hash: "abc")).to be_nil
+        expect(Block.btc.find_by(block_hash: "abc")).to be_present
+      end
+    end
+
+    context "local block with block_hash exists and it matches the remote_block" do
+      let!(:block_btc) do
+        create(:block, height: 210, coin: "btc", block_hash: "abd")
+      end
+      let!(:block_eth) do
+        create(:block, height: 210, coin: "eth", block_hash: "abd")
+      end
+
+      it "does nothing" do
+        described_class.execute(remote_block: remote_block)
+        expect(Block.eth.find_by(block_hash: "abd")).to be_present
+        expect(Block.btc.find_by(block_hash: "abd")).to be_present
+      end
+    end
+
+  end
+end

--- a/spec/services/eth/get_blocks_to_sync_spec.rb
+++ b/spec/services/eth/get_blocks_to_sync_spec.rb
@@ -32,13 +32,6 @@ module Eth
           confirmations: described_class::MAX_CONFS-1,
         })
       end
-      let!(:block_btc_1) do
-        create(:block, {
-          coin: "btc",
-          height: 2,
-          confirmations: described_class::MAX_CONFS-1,
-        })
-      end
 
       it "sets unsynced_blocks to include earliest insufficiently confirmed block until the current block number" do
         resulting_ctx = described_class.execute(current_block_number: 7)


### PR DESCRIPTION
There's an instance where the two blocks with the same height appeared but had different block hashes. This is probably caused by a network fork.

The issue this caused was that extra jobs were created because those blocks that forked stayed at a low confirmation, and our logic to select which range of blocks to sync will select from the earliest block with the lowest confirmation.

The fix would be to delete blocks that have been forked.