### PR TITLE
Increase MessageBus data retention

### DIFF
--- a/config/initializers/message_bus.rb
+++ b/config/initializers/message_bus.rb
@@ -4,6 +4,7 @@ else
   MessageBus.configure({
     backend: :postgres,
     backend_options: ENV["MESSAGE_BUS_PG_CONNECTION_STRING"],
+    clear_every: 1_000,
   })
 
   # 10 days in seconds

--- a/config/initializers/message_bus.rb
+++ b/config/initializers/message_bus.rb
@@ -5,4 +5,14 @@ else
     backend: :postgres,
     backend_options: ENV["MESSAGE_BUS_PG_CONNECTION_STRING"],
   })
+
+  # 10 days in seconds
+  MessageBus.reliable_pub_sub.max_backlog_age =
+    ENV.fetch("MESSAGE_BUS_MAX_BACKLOG_AGE") { 10 * 24 * 60 * 60 }.to_i
+
+  MessageBus.reliable_pub_sub.max_backlog_size =
+    ENV.fetch("MESSAGE_BUS_MAX_BACKLOG_SIZE") { 10_000_000 }.to_i
+
+  MessageBus.reliable_pub_sub.max_global_backlog_size =
+    ENV.fetch("MESSAGE_BUS_MAX_GLOBAL_BACKLOG_SIZE") { 10_000_000 }.to_i
 end


### PR DESCRIPTION
MessageBus by default retains up to 100 million messages up to 10 days