### PR TITLE
Refactor block scopes

### DIFF
--- a/app/services/btc/check_txs.rb
+++ b/app/services/btc/check_txs.rb
@@ -10,6 +10,7 @@ module Btc
     def self.actions
       [
         InitBitcoinerClient,
+        SetBlocks,
         GetCurrentBlock,
         GetBlocksToSync,
         iterate(:unsynced_blocks, [

--- a/app/services/btc/delete_forked_block.rb
+++ b/app/services/btc/delete_forked_block.rb
@@ -2,12 +2,12 @@ module Btc
   class DeleteForkedBlock
 
     extend LightService::Action
-    expects :remote_block
+    expects :blocks, :remote_block
 
     executed do |c|
       height = c.remote_block["height"]
       block_hash = c.remote_block["hash"]
-      forked_blocks = Block.btc.where(height: height).
+      forked_blocks = c.blocks.where(height: height).
         where.not(block_hash: block_hash)
       forked_blocks.destroy_all
     end

--- a/app/services/btc/get_blocks_to_sync.rb
+++ b/app/services/btc/get_blocks_to_sync.rb
@@ -3,17 +3,17 @@ module Btc
 
     MAX_CONFS = 10
     extend LightService::Action
-    expects :current_block_number
+    expects :blocks, :current_block_number
     promises :unsynced_blocks
 
     executed do |c|
-      blocks = Block.btc
-      insufficiently_confirmed_blocks = blocks.with_confirmations_less_than(MAX_CONFS).
+      insufficiently_confirmed_blocks = c.blocks.
+        with_confirmations_less_than(MAX_CONFS).
         order(height: :asc)
 
       if block = insufficiently_confirmed_blocks.first
         c.unsynced_blocks = Array(block.height..c.current_block_number)
-      elsif block = blocks.order(height: :asc).last
+      elsif block = c.blocks.order(height: :asc).last
         c.unsynced_blocks = (block.height..c.current_block_number).to_a
       else
         c.unsynced_blocks = Array(c.current_block_number)

--- a/app/services/btc/save_block_info.rb
+++ b/app/services/btc/save_block_info.rb
@@ -2,12 +2,12 @@ module Btc
   class SaveBlockInfo
 
     extend LightService::Action
-    expects :remote_block
+    expects :blocks, :remote_block
     promises :block
 
     executed do |c|
       remote_block = c.remote_block
-      block = Block.btc.where(block_hash: remote_block["hash"]).
+      block = c.blocks.where(block_hash: remote_block["hash"]).
         first_or_initialize
       block.update_attributes!(
         height: remote_block["height"],

--- a/app/services/btc/set_blocks.rb
+++ b/app/services/btc/set_blocks.rb
@@ -1,0 +1,12 @@
+module Btc
+  class SetBlocks
+
+    extend LightService::Action
+    promises :blocks
+
+    executed do |c|
+      c.blocks = Block.btc
+    end
+
+  end
+end

--- a/app/services/btc/sync_block.rb
+++ b/app/services/btc/sync_block.rb
@@ -10,6 +10,7 @@ module Btc
     def self.actions
       [
         InitBitcoinerClient,
+        SetBlocks,
         GetBlockHash,
         GetRemoteBlock,
         DeleteForkedBlock,

--- a/app/services/eth/check_txs.rb
+++ b/app/services/eth/check_txs.rb
@@ -11,6 +11,7 @@ module Eth
       [
         InitEthereumClient,
         GetCurrentBlock,
+        SetBlocks,
         GetBlocksToSync,
         iterate(:unsynced_blocks, [
           EnqueueSyncBlockJob,

--- a/app/services/eth/delete_forked_block.rb
+++ b/app/services/eth/delete_forked_block.rb
@@ -2,12 +2,12 @@ module Eth
   class DeleteForkedBlock
 
     extend LightService::Action
-    expects :remote_block
+    expects :blocks, :remote_block
 
     executed do |c|
       height = c.remote_block["number"].to_i(16)
       block_hash = c.remote_block["hash"]
-      forked_blocks = Block.eth.where(height: height).
+      forked_blocks = c.blocks.where(height: height).
         where.not(block_hash: block_hash)
       forked_blocks.destroy_all
     end

--- a/app/services/eth/get_blocks_to_sync.rb
+++ b/app/services/eth/get_blocks_to_sync.rb
@@ -3,11 +3,11 @@ module Eth
 
     MAX_CONFS = 20
     extend LightService::Action
-    expects :current_block_number
+    expects :blocks, :current_block_number
     promises :unsynced_blocks
 
     executed do |c|
-      block_heights_with_insufficient_confirmations = Block.eth.
+      block_heights_with_insufficient_confirmations = c.blocks.
         with_confirmations_less_than(MAX_CONFS).
         order(height: :asc)
       earliest_insufficiently_confirmed_block =

--- a/app/services/eth/save_block_info.rb
+++ b/app/services/eth/save_block_info.rb
@@ -2,12 +2,12 @@ module Eth
   class SaveBlockInfo
 
     extend LightService::Action
-    expects :remote_block, :current_block_number
+    expects :blocks, :remote_block, :current_block_number
     promises :block
 
     executed do |c|
       remote_block = c.remote_block
-      block = Block.eth.where(block_hash: remote_block["hash"]).
+      block = c.blocks.where(block_hash: remote_block["hash"]).
         first_or_initialize
 
       height = remote_block["number"].to_i(16)

--- a/app/services/eth/set_blocks.rb
+++ b/app/services/eth/set_blocks.rb
@@ -1,0 +1,12 @@
+module Eth
+  class SetBlocks
+
+    extend LightService::Action
+    promises :blocks
+
+    executed do |c|
+      c.blocks = Block.eth
+    end
+
+  end
+end

--- a/app/services/eth/sync_block.rb
+++ b/app/services/eth/sync_block.rb
@@ -10,6 +10,7 @@ module Eth
     def self.actions
       [
         InitEthereumClient,
+        SetBlocks,
         GetCurrentBlock,
         GetRemoteBlock,
         DeleteForkedBlock,

--- a/spec/fixtures/vcr_cassettes/Eth_CheckTxs/enqueues_blocks_to_sync.yml
+++ b/spec/fixtures/vcr_cassettes/Eth_CheckTxs/enqueues_blocks_to_sync.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "[ETHEREUM_HOST]/"
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ethereum-testnet.bloomx.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '45'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 18 Apr 2018 00:35:37 GMT
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x2eaf07"}
+
+'
+    http_version: 
+  recorded_at: Wed, 18 Apr 2018 00:35:37 GMT
+recorded_with: VCR 4.0.0

--- a/spec/services/btc/delete_forked_block_spec.rb
+++ b/spec/services/btc/delete_forked_block_spec.rb
@@ -9,13 +9,9 @@ module Btc
       let!(:block_btc) do
         create(:block, height: 210, coin: "btc", block_hash: "abc")
       end
-      let!(:block_eth) do
-        create(:block, height: 210, coin: "eth", block_hash: "abc")
-      end
 
       it "deletes the local block" do
-        described_class.execute(remote_block: remote_block)
-        expect(Block.eth.find_by(block_hash: "abc")).to be_present
+        described_class.execute(remote_block: remote_block, blocks: Block.btc)
         expect(Block.btc.find_by(block_hash: "abc")).to be_nil
       end
     end
@@ -24,13 +20,9 @@ module Btc
       let!(:block_btc) do
         create(:block, height: 210, coin: "btc", block_hash: "abd")
       end
-      let!(:block_eth) do
-        create(:block, height: 210, coin: "eth", block_hash: "abd")
-      end
 
       it "does nothing" do
-        described_class.execute(remote_block: remote_block)
-        expect(Block.eth.find_by(block_hash: "abd")).to be_present
+        described_class.execute(remote_block: remote_block, blocks: Block.btc)
         expect(Block.btc.find_by(block_hash: "abd")).to be_present
       end
     end

--- a/spec/services/btc/get_blocks_to_sync_spec.rb
+++ b/spec/services/btc/get_blocks_to_sync_spec.rb
@@ -6,7 +6,10 @@ module Btc
     context "there are no block records" do
       let(:current_block_number) { 23 }
       let(:resulting_ctx) do
-        described_class.execute(current_block_number: current_block_number)
+        described_class.execute(
+          current_block_number: current_block_number,
+          blocks: Block.btc,
+        )
       end
       subject { resulting_ctx.unsynced_blocks }
       it { is_expected.to match_array [23] }
@@ -15,16 +18,14 @@ module Btc
     context "there are block records; there are unknown blocks" do
       let(:current_block_number) { 23 }
       let(:resulting_ctx) do
-        described_class.execute(current_block_number: current_block_number)
+        described_class.execute(
+          current_block_number: current_block_number,
+          blocks: Block.btc,
+        )
       end
       subject { resulting_ctx.unsynced_blocks }
 
       before do
-        create(:block, {
-          coin: "eth",
-          height: 22,
-          confirmations: described_class::MAX_CONFS,
-        })
         create(:block, {
           coin: "btc",
           height: 20,
@@ -40,7 +41,10 @@ module Btc
     context "there are block records; there are blocks with unsufficient confirmations" do
       let(:current_block_number) { 23 }
       let(:resulting_ctx) do
-        described_class.execute(current_block_number: current_block_number)
+        described_class.execute(
+          current_block_number: current_block_number,
+          blocks: Block.btc,
+        )
       end
       subject { resulting_ctx.unsynced_blocks }
 

--- a/spec/services/btc/save_block_info_spec.rb
+++ b/spec/services/btc/save_block_info_spec.rb
@@ -8,14 +8,6 @@ module Btc
     end
 
     context "block exists" do
-      let!(:block_eth) do
-        create(:block, {
-          coin: "eth",
-          block_hash: "abc",
-          confirmations: 2,
-          height: 1292030,
-        })
-      end
       let!(:block_btc) do
         create(:block, {
           coin: "btc",
@@ -26,7 +18,10 @@ module Btc
       end
 
       it "updates the block info" do
-        block = described_class.execute(remote_block: remote_block).block
+        block = described_class.execute(
+          remote_block: remote_block,
+          blocks: Block.btc,
+        ).block
         expect(block).to eq block_btc
         expect(block.confirmations).to eq 3
       end
@@ -34,7 +29,10 @@ module Btc
 
     context "block does not exist" do
       it "saves the block info" do
-        block = described_class.execute(remote_block: remote_block).block
+        block = described_class.execute(
+          remote_block: remote_block,
+          blocks: Block.btc,
+        ).block
         expect(block).to be_btc
         expect(block.block_hash).to eq "abc"
         expect(block.confirmations).to eq 3

--- a/spec/services/btc/set_blocks_spec.rb
+++ b/spec/services/btc/set_blocks_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+module Btc
+  RSpec.describe SetBlocks do
+
+    it "sets blocks to btc blocks" do
+      resulting_ctx = described_class.execute
+      expect(resulting_ctx.blocks.to_sql).to eq Block.btc.to_sql
+    end
+
+  end
+end

--- a/spec/services/eth/check_txs_spec.rb
+++ b/spec/services/eth/check_txs_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+module Eth
+  RSpec.describe CheckTxs, vcr: {record: :once} do
+
+    it "enqueues blocks to sync" do
+      described_class.()
+      # NOTE: Number below is hard-coded in the cassette.
+      # Change when re-recording
+      expect(SyncBlockJob).to have_enqueued_sidekiq_job(3059463)
+    end
+
+  end
+end

--- a/spec/services/eth/delete_forked_block_spec.rb
+++ b/spec/services/eth/delete_forked_block_spec.rb
@@ -8,32 +8,24 @@ module Eth
     end
 
     context "local block with block_height exists whose hash does not match the remote_block" do
-      let!(:block_btc) do
-        create(:block, height: 210, coin: "btc", block_hash: "abc")
-      end
       let!(:block_eth) do
         create(:block, height: 210, coin: "eth", block_hash: "abc")
       end
 
       it "deletes the local block" do
-        described_class.execute(remote_block: remote_block)
+        described_class.execute(remote_block: remote_block, blocks: Block.eth)
         expect(Block.eth.find_by(block_hash: "abc")).to be_nil
-        expect(Block.btc.find_by(block_hash: "abc")).to be_present
       end
     end
 
     context "local block with block_hash exists and it matches the remote_block" do
-      let!(:block_btc) do
-        create(:block, height: 210, coin: "btc", block_hash: "abd")
-      end
       let!(:block_eth) do
         create(:block, height: 210, coin: "eth", block_hash: "abd")
       end
 
       it "does nothing" do
-        described_class.execute(remote_block: remote_block)
+        described_class.execute(remote_block: remote_block, blocks: Block.eth)
         expect(Block.eth.find_by(block_hash: "abd")).to be_present
-        expect(Block.btc.find_by(block_hash: "abd")).to be_present
       end
     end
 

--- a/spec/services/eth/get_blocks_to_sync_spec.rb
+++ b/spec/services/eth/get_blocks_to_sync_spec.rb
@@ -25,16 +25,12 @@ module Eth
           confirmations: described_class::MAX_CONFS-1,
         })
       end
-      let!(:block_btc_8) do
-        create(:block, {
-          coin: "btc",
-          height: 8,
-          confirmations: described_class::MAX_CONFS-1,
-        })
-      end
 
       it "sets unsynced_blocks to include earliest insufficiently confirmed block until the current block number" do
-        resulting_ctx = described_class.execute(current_block_number: 7)
+        resulting_ctx = described_class.execute(
+          current_block_number: 7,
+          blocks: Block.eth,
+        )
         expected_unsynced_blocks = 3..7
         expect(resulting_ctx.unsynced_blocks).
           to match_array(expected_unsynced_blocks)
@@ -43,7 +39,10 @@ module Eth
 
     context "there are no ethereum blocks" do
       it "sets unsynced_blocks to include just the current_block_number" do
-        resulting_ctx = described_class.execute(current_block_number: 35)
+        resulting_ctx = described_class.execute(
+          current_block_number: 35,
+          blocks: Block.eth,
+        )
         expect(resulting_ctx.unsynced_blocks).to match_array([35])
       end
     end

--- a/spec/services/eth/save_block_info_spec.rb
+++ b/spec/services/eth/save_block_info_spec.rb
@@ -17,19 +17,12 @@ module Eth
           height: 1292030,
         })
       end
-      let!(:block_btc) do
-        create(:block, {
-          coin: "btc",
-          block_hash: "abc",
-          confirmations: 2,
-          height: 1292030,
-        })
-      end
 
       it "updates the block info" do
         block = described_class.execute(
           remote_block: remote_block,
           current_block_number: current_block_number,
+          blocks: Block.eth,
         ).block
         expect(block).to eq block_eth
         expect(block.confirmations).to eq 11
@@ -42,6 +35,7 @@ module Eth
         block = described_class.execute(
           remote_block: remote_block,
           current_block_number: current_block_number,
+          blocks: Block.eth,
         ).block
         expect(block).to be_eth
         expect(block.block_hash).to eq "abc"

--- a/spec/services/eth/set_blocks_spec.rb
+++ b/spec/services/eth/set_blocks_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+module Eth
+  RSpec.describe SetBlocks do
+
+    it "sets blocks to eth blocks" do
+      resulting_ctx = described_class.execute
+      expect(resulting_ctx.blocks.to_sql).to eq Block.eth.to_sql
+    end
+
+  end
+end


### PR DESCRIPTION
Rely on an action to pass the scope of blocks that the rest of the actions will work with. Less prone to scoping issues.