### PR TITLE
Sync eth blocks up to 150 confs

### DIFF
--- a/app/services/eth/get_blocks_to_sync.rb
+++ b/app/services/eth/get_blocks_to_sync.rb
@@ -1,7 +1,7 @@
 module Eth
   class GetBlocksToSync
 
-    MAX_CONFS = 20
+    MAX_CONFS = 150
     extend LightService::Action
     expects :blocks, :current_block_number
     promises :unsynced_blocks


### PR DESCRIPTION
https://ethereum.stackexchange.com/questions/319/what-number-of-confirmations-is-considered-secure-in-ethereum

150 is closer to 250 (in the discussion above). Seems like a reasonable amount for now