### PR TITLE
Add job and services to sync missing blocks

### DIFF
--- a/app/jobs/sync_missing_blocks_job.rb
+++ b/app/jobs/sync_missing_blocks_job.rb
@@ -1,0 +1,9 @@
+class SyncMissingBlocksJob < ApplicationJob
+
+  sidekiq_options unique: :until_executed
+
+  def perform(coin)
+    SyncMissingBlocks.(coin)
+  end
+
+end

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -14,4 +14,17 @@ class Block < ApplicationRecord
     where(confirmations.lt(n))
   end
 
+  scope :with_height_greater_than_or_equal_to, ->(height) do
+    where(arel_table[:height].gteq(height))
+  end
+
+  scope :with_height_less_than_or_equal_to, ->(height) do
+    where(arel_table[:height].lteq(height))
+  end
+
+  class << self
+    alias :with_height_gteq :with_height_greater_than_or_equal_to
+    alias :with_height_lteq :with_height_less_than_or_equal_to
+  end
+
 end

--- a/app/services/detect_block_gaps.rb
+++ b/app/services/detect_block_gaps.rb
@@ -1,0 +1,32 @@
+class DetectBlockGaps
+
+  extend LightService::Action
+  expects :blocks
+  promises :unsynced_blocks
+
+  SEARCH_INCREMENT = 1_000
+
+  executed do |c|
+    blocks = c.blocks.order(height: :asc)
+    limit = blocks.last.height
+    c.unsynced_blocks = get_missing_blocks_in(blocks, 1, limit)
+  end
+
+  def self.get_missing_blocks_in(blocks, start_height, limit)
+    return [] if start_height >= limit
+
+    end_height = start_height + SEARCH_INCREMENT
+    end_height = limit if end_height > limit
+
+    scoped_blocks = blocks.
+      with_height_gteq(start_height).
+      with_height_lteq(end_height)
+
+    missing_block_heights =
+      (start_height..end_height).to_set - scoped_blocks.pluck(:height).to_set
+
+    missing_block_heights.to_a +
+      get_missing_blocks_in(blocks, end_height+1, limit)
+  end
+
+end

--- a/app/services/sync_missing_blocks.rb
+++ b/app/services/sync_missing_blocks.rb
@@ -1,0 +1,22 @@
+class SyncMissingBlocks
+
+  extend LightService::Organizer
+
+  def self.call(coin)
+    reduce(actions_for(coin))
+  end
+
+  private
+
+  def self.actions_for(coin)
+    coin_namespace = coin.classify.constantize
+    [
+      coin_namespace.const_get("SetBlocks"),
+      DetectBlockGaps,
+      iterate(:unsynced_blocks, [
+        coin_namespace.const_get("EnqueueSyncBlockJob"),
+      ])
+    ]
+  end
+
+end

--- a/spec/jobs/sync_missing_blocks_job_spec.rb
+++ b/spec/jobs/sync_missing_blocks_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe SyncMissingBlocksJob do
+
+  it "inherits from ApplicationJob" do
+    expect(described_class < ApplicationJob).to be true
+  end
+
+  it "is unique until_executed" do
+    expect(described_class.sidekiq_options["unique"]).to eq :until_executed
+  end
+
+  %w(btc eth).each do |coin|
+    # NOTE: not all Block::COINS are synced, yet
+    context "given the arg `#{coin}`" do
+      it "delegates work to #{coin.classify}::SyncMissingBlocks" do
+        expect(SyncMissingBlocks).to receive(:call).with(coin)
+        described_class.new.perform(coin)
+      end
+    end
+  end
+
+end

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -25,4 +25,43 @@ RSpec.describe Block do
     end
   end
 
+  describe ".with_height_greater_than_or_equal_to" do
+    let!(:block_1) { create(:block, height: 12) }
+    let!(:block_2) { create(:block, height: 11) }
+    let!(:block_3) { create(:block, height: 9) }
+
+    it "returns the blocks with the height greater than or equal to the integer" do
+      expect(described_class.with_height_greater_than_or_equal_to(11)).
+        to match_array([block_1, block_2])
+      expect(described_class.with_height_greater_than_or_equal_to(12)).
+        to match_array([block_1])
+      expect(described_class.with_height_greater_than_or_equal_to(2)).
+        to match_array([block_1, block_2, block_3])
+    end
+
+    it "aliases .with_height_gteq" do
+      expect(described_class.with_height_gteq(11)).
+        to match_array([block_1, block_2])
+    end
+  end
+
+  describe ".with_height_greater_than_or_equal_to" do
+    let!(:block_1) { create(:block, height: 12) }
+    let!(:block_2) { create(:block, height: 11) }
+    let!(:block_3) { create(:block, height: 9) }
+
+    it "returns the blocks with the height less than or equal to the integer" do
+      expect(described_class.with_height_less_than_or_equal_to(11)).
+        to match_array([block_2, block_3])
+      expect(described_class.with_height_less_than_or_equal_to(12)).
+        to match_array([block_1, block_2, block_3])
+      expect(described_class.with_height_less_than_or_equal_to(2)).to be_empty
+    end
+
+    it "aliases .with_height_lteq" do
+      expect(described_class.with_height_lteq(11)).
+        to match_array([block_2, block_3])
+    end
+  end
+
 end

--- a/spec/services/detect_block_gaps_spec.rb
+++ b/spec/services/detect_block_gaps_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe DetectBlockGaps do
+
+  let!(:block_8) { create(:block, coin: "btc", height: 8) }
+  let!(:block_5) { create(:block, coin: "btc", height: 5) }
+  let!(:block_1) { create(:block, coin: "btc", height: 1) }
+  let!(:block_2) { create(:block, coin: "btc", height: 2) }
+  let!(:block_4) { create(:block, coin: "btc", height: 4) }
+
+  it "detects gaps in blocks" do
+    resulting_ctx = described_class.execute(blocks: Block.btc)
+    expect(resulting_ctx.unsynced_blocks).to match_array([3, 6, 7])
+  end
+
+end

--- a/spec/services/sync_missing_blocks_spec.rb
+++ b/spec/services/sync_missing_blocks_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe SyncMissingBlocks do
+
+  # NOTE: btc and eth for now
+  %w(btc eth).each do |coin|
+    describe "given `#{coin}` param" do
+      let!(:block_1) { create(:block, coin: coin, height: 1) }
+      let!(:block_3) { create(:block, coin: coin, height: 3) }
+
+      it "enqueues missing blocks" do
+        described_class.(coin)
+        coin_namespace = coin.classify.constantize
+        job_class = coin_namespace.const_get("SyncBlockJob")
+        expect(job_class).to have_enqueued_sidekiq_job(2)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
For whatever reason, if the normal `CheckTxs` services miss a block, this is what we can run to recover from missing blocks.

This will be run on a schedule, probably every day. The schedule isn't included yet as performance tests will need to be performed on staging before we automate it.