### PR TITLE
Fixes generation of testnet multisig addresses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/bloom-solutions/btcruby.git
-  revision: 96f555012e684a7fc5abf9896dd783cb7b320136
+  revision: d0a7f0c9eca61c3e038bf16ca717d55e65155c12
   branch: bloom_changes
   specs:
     btcruby (1.7)

--- a/app/lib/btc/address_generator.rb
+++ b/app/lib/btc/address_generator.rb
@@ -25,11 +25,10 @@ module Btc
 
     def multisig_address(idx)
       keychain_group = BTC::KeychainGroup.new(extended_keys: xpub)
-      multisig_script = keychain_group.multisig_script({
+      keychain_group.standard_address({
         index: idx,
-        signatures_required: self.signatures_required,
+        signatures_required: signatures_required,
       })
-      multisig_script.p2sh_script.standard_address.to_s
     end
 
     def single_address(idx)


### PR DESCRIPTION
Use newer version of btcruby that auto-generates the testnet multisig address if testnet extended keys are given