### PR TITLE
Sync missing blocks every hour

### DIFF
--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -21,3 +21,15 @@ sync_unconfirmed_eth_txs:
   class: "SyncUnconfirmedTxsJob"
   args:
     - "eth"
+
+sync_btc_missing_blocks:
+  cron: "0 0 * * *"
+  class: "SyncMissingBlocksJob"
+  args:
+    - "btc"
+
+sync_eth_missing_blocks:
+  cron: "0 0 * * *"
+  class: "SyncMissingBlocksJob"
+  args:
+    - "eth"


### PR DESCRIPTION
It takes, on average 2.5 ms to scan 1,000 blocks. The most I've seen is 3.2 ms. Acting conservatively, let's work with 5ms per 1,000 blocks.

Even if we scan from the first Ethereum block, we'll have 3.2 million blocks to scan. At 4 ms per 1,000 blocks, it will take about 13 seconds to run this job.

It seems that running this every hour is cheap enough, and when there are 100's of millions of blocks to scan we can look at a more efficient way without much more effort, like having a cursor so we know what blocks we have already double checked and can therefore skip.