### PR TITLE
Publish data as JSON and not a string

### DIFF
--- a/app/services/notify_tx_receipt.rb
+++ b/app/services/notify_tx_receipt.rb
@@ -16,7 +16,7 @@ class NotifyTxReceipt
       amount: c.tx.amount,
       confirmations: c.tx.confirmations,
     }
-    MessageBus.publish CHANNEL, data.to_json
+    MessageBus.publish CHANNEL, data
 
     Rails.logger.info(data)
   end

--- a/spec/services/notify_tx_receipt_spec.rb
+++ b/spec/services/notify_tx_receipt_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe NotifyTxReceipt do
     described_class.execute(tx: tx)
     messages = MessageBus.backlog described_class::CHANNEL, 0
     expect(messages.count).to be > 0
-    data = JSON.parse(messages.last.data)
+    data = messages.last.data
     expect(data["coin"]).to eq "btc"
     expect(data["code"]).to eq "123"
     expect(data["tx_id"]).to eq "txid"


### PR DESCRIPTION
No need to do the extra work. Allow clients to accept JSON and not have to parse it.