### PR TITLE
Slice up fetching of blocks

### DIFF
--- a/app/services/btc/get_remote_blocks.rb
+++ b/app/services/btc/get_remote_blocks.rb
@@ -5,15 +5,19 @@ module Btc
     expects :bitcoiner_client, :block_hashes
     promises :remote_blocks
     VERBOSITY = 2
+    SLICE = 10.freeze
 
     executed do |c|
       args = c.block_hashes.map do |block_hash|
         ["getblock", [block_hash, VERBOSITY]]
       end
 
-      response = c.bitcoiner_client.request(args)
+      c.remote_blocks = []
 
-      c.remote_blocks = response.map { |hash| hash["result"] }
+      args.each_slice(SLICE) do |a|
+        response = c.bitcoiner_client.request(a)
+        c.remote_blocks += response.map { |hash| hash["result"] }
+      end
     end
 
   end


### PR DESCRIPTION
10 blocks takes about 12 seconds in the few calls made to test. When the system lags for whatever reason and many blocks need to be synced, the bitcoin nodes end up dying because they run out of memory. Instead of spiking the system memory usage a lot, slice up the txs we fetch.