### PR TITLE
Batch search

### DIFF
--- a/app/services/btc/append_output_address.rb
+++ b/app/services/btc/append_output_address.rb
@@ -1,0 +1,12 @@
+module Btc
+  class AppendOutputAddress
+
+    extend LightService::Action
+    expects :output_addresses, :remote_tx_output_addresses
+
+    executed do |c|
+      c.output_addresses += c.remote_tx_output_addresses
+    end
+
+  end
+end

--- a/app/services/btc/find_address.rb
+++ b/app/services/btc/find_address.rb
@@ -2,21 +2,13 @@ module Btc
   class FindAddress
 
     extend LightService::Action
-    expects :remote_tx, :remote_tx_output
+    expects :remote_tx_output_addresses
     promises :address
 
-    SUPPORTED_SCRIPT_PUB_KEY_TYPES = %w(pubkeyhash scripthash)
-
     executed do |c|
-      script_pub_key = c.remote_tx_output["scriptPubKey"]
-      if SUPPORTED_SCRIPT_PUB_KEY_TYPES.include?(script_pub_key["type"])
-        public_address = script_pub_key["addresses"].first
-        c.address = Address.btc.find_by(address: public_address)
-        c.skip_remaining! if c.address.nil?
-      else
-        c.address = nil
-        c.skip_remaining!
-      end
+      public_address = c.remote_tx_output_addresses.first
+      c.address = Address.btc.find_by(address: public_address)
+      c.skip_remaining! if c.address.nil?
     end
 
   end

--- a/app/services/btc/get_output_addresses.rb
+++ b/app/services/btc/get_output_addresses.rb
@@ -1,0 +1,27 @@
+module Btc
+  class GetOutputAddresses
+
+    extend LightService::Organizer
+    extend LightService::Action
+    expects :remote_txs
+    promises :output_addresses
+
+    def self.call(ctx)
+      ctx[:output_addresses] = []
+      with(ctx).reduce(actions)
+    end
+
+    def self.actions
+      [
+        iterate(:remote_txs, [
+          GetRemoteTxOutputs,
+          iterate(:remote_tx_outputs, [
+            GetRemoteTxOutputAddresses,
+            AppendOutputAddress,
+          ])
+        ])
+      ]
+    end
+
+  end
+end

--- a/app/services/btc/get_remote_tx_output_addresses.rb
+++ b/app/services/btc/get_remote_tx_output_addresses.rb
@@ -1,0 +1,21 @@
+module Btc
+  class GetRemoteTxOutputAddresses
+
+    extend LightService::Action
+    expects :remote_tx, :remote_tx_output
+    promises :remote_tx_output_addresses
+
+    SUPPORTED_SCRIPT_PUB_KEY_TYPES = %w(pubkeyhash scripthash)
+
+    executed do |c|
+      script_pub_key = c.remote_tx_output["scriptPubKey"]
+      if SUPPORTED_SCRIPT_PUB_KEY_TYPES.include?(script_pub_key["type"])
+        c.remote_tx_output_addresses = script_pub_key["addresses"]
+      else
+        c.remote_tx_output_addresses = []
+        c.skip_remaining!
+      end
+    end
+
+  end
+end

--- a/app/services/btc/process_remote_txs.rb
+++ b/app/services/btc/process_remote_txs.rb
@@ -9,20 +9,21 @@ module Btc
       with(ctx).reduce(actions)
     end
 
-    executed do |c|
-      self.(c)
-    end
-
     def self.actions
-      iterate(:remote_txs, [
-        GetRemoteTxOutputs,
-        iterate(:remote_tx_outputs, [
-          GetRemoteTxOutputAddresses,
-          FindAddress,
-          SaveTxInfo,
-          NotifyTxReceipt,
-        ])
-      ])
+      [
+        GetOutputAddresses,
+        reduce_if(->(c) { Address.where(address: c.output_addresses).any? }, [
+          iterate(:remote_txs, [
+            GetRemoteTxOutputs,
+            iterate(:remote_tx_outputs, [
+              GetRemoteTxOutputAddresses,
+              FindAddress,
+              SaveTxInfo,
+              NotifyTxReceipt,
+            ])
+          ])
+        ]),
+      ]
     end
 
   end

--- a/app/services/btc/process_remote_txs.rb
+++ b/app/services/btc/process_remote_txs.rb
@@ -5,21 +5,24 @@ module Btc
     extend LightService::Action
     expects :remote_txs
 
+    def self.call(ctx)
+      with(ctx).reduce(actions)
+    end
+
     executed do |c|
-      with(c).reduce(actions)
+      self.(c)
     end
 
     def self.actions
-      [
-        iterate(:remote_txs, [
-          GetRemoteTxOutputs,
-          iterate(:remote_tx_outputs, [
-            FindAddress,
-            SaveTxInfo,
-            NotifyTxReceipt,
-          ])
+      iterate(:remote_txs, [
+        GetRemoteTxOutputs,
+        iterate(:remote_tx_outputs, [
+          GetRemoteTxOutputAddresses,
+          FindAddress,
+          SaveTxInfo,
+          NotifyTxReceipt,
         ])
-      ]
+      ])
     end
 
   end

--- a/app/services/btc/process_remote_txs.rb
+++ b/app/services/btc/process_remote_txs.rb
@@ -1,0 +1,26 @@
+module Btc
+  class ProcessRemoteTxs
+
+    extend LightService::Organizer
+    extend LightService::Action
+    expects :remote_txs
+
+    executed do |c|
+      with(c).reduce(actions)
+    end
+
+    def self.actions
+      [
+        iterate(:remote_txs, [
+          GetRemoteTxOutputs,
+          iterate(:remote_tx_outputs, [
+            FindAddress,
+            SaveTxInfo,
+            NotifyTxReceipt,
+          ])
+        ])
+      ]
+    end
+
+  end
+end

--- a/app/services/btc/sync_blocks.rb
+++ b/app/services/btc/sync_blocks.rb
@@ -17,14 +17,7 @@ module Btc
           SaveBlockInfo,
         ]),
         GetRemoteBlocksTxs,
-        iterate(:remote_txs, [
-          GetRemoteTxOutputs,
-          iterate(:remote_tx_outputs, [
-            FindAddress,
-            SaveTxInfo,
-            NotifyTxReceipt,
-          ])
-        ])
+        ProcessRemoteTxs,
       ]
     end
 

--- a/app/services/btc/sync_unconfirmed_txs.rb
+++ b/app/services/btc/sync_unconfirmed_txs.rb
@@ -12,14 +12,7 @@ module Btc
         InitBitcoinerClient,
         GetRawMempoolTxIds,
         GetRemoteTxsFromTxIds,
-        iterate(:remote_txs, [
-          GetRemoteTxOutputs,
-          iterate(:remote_tx_outputs, [
-            FindAddress,
-            SaveTxInfo,
-            NotifyTxReceipt,
-          ])
-        ]),
+        ProcessRemoteTxs,
         DeleteDroppedUnconfirmedTxs,
       ]
     end

--- a/app/services/sync_missing_blocks.rb
+++ b/app/services/sync_missing_blocks.rb
@@ -22,14 +22,7 @@ class SyncMissingBlocks
           Btc::SaveBlockInfo,
         ]),
         Btc::GetRemoteBlocksTxs,
-        iterate(:remote_txs, [
-          Btc::GetRemoteTxOutputs,
-          iterate(:remote_tx_outputs, [
-            Btc::FindAddress,
-            Btc::SaveTxInfo,
-            NotifyTxReceipt,
-          ])
-        ])
+        Btc::ProcessRemoteTxs,
       ]
     when "eth"
       [

--- a/spec/fixtures/vcr_cassettes/SyncMissingBlocks/given_btc_param/enqueues_missing_blocks.yml
+++ b/spec/fixtures/vcr_cassettes/SyncMissingBlocks/given_btc_param/enqueues_missing_blocks.yml
@@ -23,14 +23,14 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 Nov 2018 03:01:29 GMT
+      - Mon, 19 Nov 2018 13:22:20 GMT
     body:
       encoding: UTF-8
       string: '[{"result":"00000000000000dfbbe02b6ca7712e19f422e46c2fd418da5751ea10b68ffbd7","error":null,"id":"jsonrpc"}]
 
 '
     http_version: 
-  recorded_at: Wed, 14 Nov 2018 03:01:29 GMT
+  recorded_at: Mon, 19 Nov 2018 13:22:20 GMT
 - request:
     method: post
     uri: "[BITCOIND_HOST]/"
@@ -50,14 +50,14 @@ http_interactions:
       message: OK
     headers:
       Content-Length:
-      - '38152'
+      - '38154'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 Nov 2018 03:01:29 GMT
+      - Mon, 19 Nov 2018 13:22:20 GMT
     body:
       encoding: UTF-8
-      string: '[{"result":{"hash":"00000000000000dfbbe02b6ca7712e19f422e46c2fd418da5751ea10b68ffbd7","confirmations":8,"strippedsize":3706,"size":5714,"weight":16832,"height":1443362,"version":1073676288,"versionHex":"3fff0000","merkleroot":"8ccc70ebcfd42d6e12a5e165c5e62c60099472565fe5654fa89bef73adabaf0b","tx":[{"txid":"aeb69367e0662fd0e0ef38c44e83b526f2f2637861531e958291bde4ae471f0d","hash":"079f667f2849ee6cf337e745a6e4a29eb8f5e655a24a01ae18297b8be608b80f","version":2,"size":200,"vsize":173,"locktime":0,"vin":[{"coinbase":"0322061604a27deb5b44434578706c6f726174696f6e09000015e008000000000000","sequence":4294967295}],"vout":[{"value":0.79089718,"n":0,"scriptPubKey":{"asm":"OP_HASH160
+      string: '[{"result":{"hash":"00000000000000dfbbe02b6ca7712e19f422e46c2fd418da5751ea10b68ffbd7","confirmations":726,"strippedsize":3706,"size":5714,"weight":16832,"height":1443362,"version":1073676288,"versionHex":"3fff0000","merkleroot":"8ccc70ebcfd42d6e12a5e165c5e62c60099472565fe5654fa89bef73adabaf0b","tx":[{"txid":"aeb69367e0662fd0e0ef38c44e83b526f2f2637861531e958291bde4ae471f0d","hash":"079f667f2849ee6cf337e745a6e4a29eb8f5e655a24a01ae18297b8be608b80f","version":2,"size":200,"vsize":173,"locktime":0,"vin":[{"coinbase":"0322061604a27deb5b44434578706c6f726174696f6e09000015e008000000000000","sequence":4294967295}],"vout":[{"value":0.79089718,"n":0,"scriptPubKey":{"asm":"OP_HASH160
         e0725ef08b0046fd2df3c58d5fefc5580e1f59de OP_EQUAL","hex":"a914e0725ef08b0046fd2df3c58d5fefc5580e1f59de87","reqSigs":1,"type":"scripthash","addresses":["2NDhzMt2D9ZxXapbuq567WGeWP7NuDN81cg"]}},{"value":0.00000000,"n":1,"scriptPubKey":{"asm":"OP_RETURN
         aa21a9ed33879dcddb84d292178b9e72bb9cb2d481686f3ff968a9246968079da434908c","hex":"6a24aa21a9ed33879dcddb84d292178b9e72bb9cb2d481686f3ff968a9246968079da434908c","type":"nulldata"}}],"hex":"020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff220322061604a27deb5b44434578706c6f726174696f6e09000015e008000000000000ffffffff0236d0b6040000000017a914e0725ef08b0046fd2df3c58d5fefc5580e1f59de870000000000000000266a24aa21a9ed33879dcddb84d292178b9e72bb9cb2d481686f3ff968a9246968079da434908c0120000000000000000000000000000000000000000000000000000000000000000000000000"},{"txid":"0f0bd99f20270a885ec3ea1c08d9b50e55c5d597a237653607f25c92d7a032de","hash":"0f0bd99f20270a885ec3ea1c08d9b50e55c5d597a237653607f25c92d7a032de","version":2,"size":271,"vsize":271,"locktime":0,"vin":[{"txid":"29b1d30d5d380bf60dddfbd489f0e6984e3af08035df011bca9b93c99408811d","vout":1,"scriptSig":{"asm":"304402206e3e07ea01613de74ebd11c361e88819e778ce0291cdbf5e13ca19c7452a6be8022064e341ba24232806d7be6576fad66f35b55481a6c3e5a773581e9cca35a2e8fe[ALL]
         03f0937a3abc7cf55ee7ede5ecc2a5d8665f4e0f56bf20b4e2bb9a99b2023326f7","hex":"47304402206e3e07ea01613de74ebd11c361e88819e778ce0291cdbf5e13ca19c7452a6be8022064e341ba24232806d7be6576fad66f35b55481a6c3e5a773581e9cca35a2e8fe012103f0937a3abc7cf55ee7ede5ecc2a5d8665f4e0f56bf20b4e2bb9a99b2023326f7"},"sequence":4294967295}],"vout":[{"value":0.00000000,"n":0,"scriptPubKey":{"asm":"OP_RETURN
@@ -108,5 +108,5 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 14 Nov 2018 03:01:29 GMT
+  recorded_at: Mon, 19 Nov 2018 13:22:20 GMT
 recorded_with: VCR 4.0.0

--- a/spec/services/btc/find_address_spec.rb
+++ b/spec/services/btc/find_address_spec.rb
@@ -3,63 +3,9 @@ require 'rails_helper'
 module Btc
   RSpec.describe FindAddress do
 
-    let(:remote_tx) do
-      {
-        "txid" => "c92f",
-        "hash" => "c92f",
-        "version" => 2,
-        "size" => 373,
-        "vsize" => 373,
-        "locktime" => 1292029,
-        "vin" => [],
-        "vout" =>  [remote_tx_output],
-        "hex" => "020000000223"
-      }
-    end
-
-    context "output is not a `pubkeyhash`" do
-      let!(:address) do
-        create(:address, {
-          coin: "btc",
-          address: "n423UweU1UvsebP1gmduMjaA2y2nz81iWR",
-        })
-      end
-      let(:remote_tx_output) do
-        {
-          "value" => 0.01001774,
-          "n" => 0,
-          "scriptPubKey" => {
-            "asm" => "asm...",
-            "hex" => "76a914f",
-            "reqSigs" => 1,
-            "type" => "multisig",
-            "addresses" => ["n423UweU1UvsebP1gmduMjaA2y2nz81iWR", "..."]
-          }
-        }
-      end
-
-      it "skips the rest of the steps" do
-        resulting_ctx = described_class.execute(
-          remote_tx: remote_tx,
-          remote_tx_output: remote_tx_output,
-        )
-        expect(resulting_ctx).to be_skip_remaining
-      end
-    end
-
-    context "address is a `pubkeyhash`" do
-      let(:remote_tx_output) do
-        {
-          "value" => 0.01001774,
-          "n" => 0,
-          "scriptPubKey" => {
-            "asm" => "asm...",
-            "hex" => "76a914f",
-            "reqSigs" => 1,
-            "type" => "pubkeyhash",
-            "addresses" => ["n423UweU1UvsebP1gmduMjaA2y2nz81iWR"]
-          }
-        }
+    context "remote_tx_output_addresses' first element exists in the db" do
+      let(:remote_tx_output_addresses) do
+        ["n423UweU1UvsebP1gmduMjaA2y2nz81iWR"]
       end
       let!(:address_1) do
         create(:address, {
@@ -76,61 +22,20 @@ module Btc
 
       it "returns the btc address matching the given public address" do
         resulting_ctx = described_class.execute(
-          remote_tx: remote_tx,
-          remote_tx_output: remote_tx_output,
-        )
-        expect(resulting_ctx.address).to eq address_2
-      end
-    end
-
-    context "address is a `scripthash`" do
-      let(:remote_tx_output) do
-        {
-          "value" => 0.01001774,
-          "n" => 0,
-          "scriptPubKey" => {
-            "asm" => "asm...",
-            "hex" => "76a914f",
-            "reqSigs" => 1,
-            "type" => "scripthash",
-            "addresses" => ["3AHSUvWK"]
-          }
-        }
-      end
-      let!(:address_1) do
-        create(:address, coin: "ltc", address: "3AHSUvWK")
-      end
-      let!(:address_2) do
-        create(:address, coin: "btc", address: "3AHSUvWK")
-      end
-
-      it "returns the btc address matching the given public address" do
-        resulting_ctx = described_class.execute(
-          remote_tx: remote_tx,
-          remote_tx_output: remote_tx_output,
+          remote_tx_output_addresses: remote_tx_output_addresses,
         )
         expect(resulting_ctx.address).to eq address_2
       end
     end
 
     context "no address is found" do
-      let(:remote_tx_output) do
-        {
-          "value" => 0.01001774,
-          "n" => 0,
-          "scriptPubKey" => {
-            "asm" => "asm...",
-            "hex" => "76a914f",
-            "reqSigs" => 1,
-            "type" => "pubkeyhash",
-            "addresses" => ["n423UweU1UvsebP1gmduMjaA2y2nz81iWR"]
-          }
-        }
+      let(:remote_tx_output_addresses) do
+        ["n423UweU1UvsebP1gmduMjaA2y2nz81iWR"]
       end
+
       it "skips the rest of the steps" do
         resulting_ctx = described_class.execute(
-          remote_tx: remote_tx,
-          remote_tx_output: remote_tx_output,
+          remote_tx_output_addresses: remote_tx_output_addresses,
         )
         expect(resulting_ctx).to be_skip_remaining
       end

--- a/spec/services/btc/get_output_addresses_spec.rb
+++ b/spec/services/btc/get_output_addresses_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+module Btc
+  RSpec.describe GetOutputAddresses do
+
+    let(:remote_txs) do
+      [
+        {
+          "vout" => [
+            {
+              "scriptPubKey" => {
+                "type" => "pubkeyhash",
+                "addresses" => ["addr1"],
+              }
+            }
+          ]
+        },
+        {
+          "vout" => [
+            {
+              "scriptPubKey" => {
+                "type" => "pubkeyhash",
+                "addresses" => ["addr2"],
+              }
+            }
+          ]
+        }
+      ]
+    end
+
+    it "sets the output_addresses found in remote_txs" do
+      resulting_ctx = described_class.(remote_txs: remote_txs)
+
+      expect(resulting_ctx.output_addresses).to match_array(%w(addr1 addr2))
+    end
+
+  end
+end

--- a/spec/services/btc/get_remote_tx_output_addresses_spec.rb
+++ b/spec/services/btc/get_remote_tx_output_addresses_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+module Btc
+  RSpec.describe GetRemoteTxOutputAddresses do
+
+    let(:remote_tx) do
+      {
+        "txid" => "c92f",
+        "hash" => "c92f",
+        "version" => 2,
+        "size" => 373,
+        "vsize" => 373,
+        "locktime" => 1292029,
+        "vin" => [],
+        "vout" =>  [remote_tx_output],
+        "hex" => "020000000223"
+      }
+    end
+
+    context "output is not a `pubkeyhash`" do
+      let(:remote_tx_output) do
+        {
+          "value" => 0.01001774,
+          "n" => 0,
+          "scriptPubKey" => {
+            "asm" => "asm...",
+            "hex" => "76a914f",
+            "reqSigs" => 1,
+            "type" => "multisig",
+            "addresses" => ["n423UweU1UvsebP1gmduMjaA2y2nz81iWR", "..."]
+          }
+        }
+      end
+
+      it "skips the rest of the steps" do
+        resulting_ctx = described_class.execute(
+          remote_tx: remote_tx,
+          remote_tx_output: remote_tx_output,
+        )
+        expect(resulting_ctx).to be_skip_remaining
+      end
+    end
+
+    context "address is a `pubkeyhash`" do
+      let(:remote_tx_output) do
+        {
+          "value" => 0.01001774,
+          "n" => 0,
+          "scriptPubKey" => {
+            "asm" => "asm...",
+            "hex" => "76a914f",
+            "reqSigs" => 1,
+            "type" => "pubkeyhash",
+            "addresses" => ["n423UweU1UvsebP1gmduMjaA2y2nz81iWR"]
+          }
+        }
+      end
+
+      it "sets remote_tx_output_addresses" do
+        resulting_ctx = described_class.execute(
+          remote_tx: remote_tx,
+          remote_tx_output: remote_tx_output,
+        )
+        expect(resulting_ctx.remote_tx_output_addresses)
+          .to match_array(["n423UweU1UvsebP1gmduMjaA2y2nz81iWR"])
+      end
+    end
+
+    context "address is a `scripthash`" do
+      let(:remote_tx_output) do
+        {
+          "value" => 0.01001774,
+          "n" => 0,
+          "scriptPubKey" => {
+            "asm" => "asm...",
+            "hex" => "76a914f",
+            "reqSigs" => 1,
+            "type" => "scripthash",
+            "addresses" => ["3AHSUvWK"]
+          }
+        }
+      end
+
+      it "returns the btc address matching the given public address" do
+        resulting_ctx = described_class.execute(
+          remote_tx: remote_tx,
+          remote_tx_output: remote_tx_output,
+        )
+        expect(resulting_ctx.remote_tx_output_addresses)
+          .to match_array(["3AHSUvWK"])
+      end
+    end
+
+  end
+end

--- a/spec/services/btc/process_remote_txs_spec.rb
+++ b/spec/services/btc/process_remote_txs_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+module Btc
+  RSpec.describe ProcessRemoteTxs do
+
+    let(:remote_txs) do
+      [
+        {
+          "txid" => "c92f",
+          "hash" => "c92f",
+          "version" => 2,
+          "size" => 373,
+          "vsize" => 373,
+          "locktime" => 1292029,
+          "vin" => [],
+          "vout" =>  [
+            {
+              "value" => 0.01001774,
+              "n" => 0,
+              "scriptPubKey" => {
+                "asm" => "asm...",
+                "hex" => "76a914f",
+                "reqSigs" => 1,
+                "type" => "pubkeyhash",
+                "addresses" => ["addr1"]
+              }
+            }
+          ],
+          "hex" => "020000000223"
+        }
+      ]
+    end
+
+    context "there are addresses that match some of the output_addresses" do
+      let!(:address) { create(:address, coin: "btc", address: "addr1") }
+
+      it "saves/updates those tx data" do
+        described_class.(remote_txs: remote_txs)
+        expect(Tx.of_coin("btc").exists?(amount: 0.01001774)).to be true
+      end
+    end
+
+    context "there are no addresses that match the output_addresses" do
+      it "does nothing" do
+        described_class.(remote_txs: remote_txs)
+        expect(Tx.of_coin("btc")).to be_empty
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Problem: going through each bitcoin output address one at a time was making our jobs take about 2 to 3 minutes.

Solution: do a batch search on the output addresses. If one of the addresses that we care about is there, it will then continue and take 2 to 3 minutes to sync up. If there are no addresses there that we care about, then it will skip the rest of the actions. On staging, this task took about 10 ms.