### PR TITLE
Retry failed jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,6 +1,5 @@
 class ApplicationJob
 
   include Sidekiq::Worker
-  sidekiq_options retry: 0
 
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -2,6 +2,4 @@ require 'rails_helper'
 
 RSpec.describe ApplicationJob do
 
-  it { is_expected.to be_retryable(0) }
-
 end


### PR DESCRIPTION
There are network calls to the the crypto nodes that fail; instead of adding to the number of failed jobs, retry.