### PR TITLE
Add Btc::GetRemoteBlocks in circuit breaker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "bip44", "0.2.14"
 gem "bitcoiner", "0.1.4"
 gem "btcruby", github: "bloom-solutions/btcruby", branch: "bloom_changes"
 gem "bugsnag", "~> 6.9"
+gem "circuitbox", "~> 1.1"
 gem "dry-initializer", "~> 2.3"
 gem "dry-types" # required by reform coercion
 gem "dry-validation"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,9 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    circuitbox (1.1.1)
+      activesupport
+      moneta
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -195,6 +198,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    moneta (1.0.0)
     money-tree (0.9.0)
       ffi
     multi_json (1.13.1)
@@ -396,6 +400,7 @@ DEPENDENCIES
   bugsnag (~> 6.9)
   byebug
   capybara (~> 2.13)
+  circuitbox (~> 1.1)
   coffee-rails (~> 4.2)
   dotenv-rails
   dry-initializer (~> 2.3)

--- a/app/services/btc/get_remote_blocks.rb
+++ b/app/services/btc/get_remote_blocks.rb
@@ -11,9 +11,17 @@ module Btc
         ["getblock", [block_hash, VERBOSITY]]
       end
 
-      response = c.bitcoiner_client.request(args)
+      response = bitcoind_circuit.run do
+        c.bitcoiner_client.request(args)
+      end
 
       c.remote_blocks = response.map { |hash| hash["result"] }
+    end
+
+    def self.bitcoind_circuit
+      Circuitbox.circuit(:bitcoind, {
+        exceptions: [Bitcoiner::Client::JSONRPCError],
+      })
     end
 
   end


### PR DESCRIPTION
Sometimes bitcoind is down or does not respond as expect; Instead of raising an error wrap the call in a circuitbox