### PR TITLE
Fetching txpool content is in a circuit

### DIFF
--- a/app/services/eth/get_pending_txs.rb
+++ b/app/services/eth/get_pending_txs.rb
@@ -16,7 +16,7 @@ module Eth
 
     def self.geth_circuit
       Circuitbox.circuit(:geth_circuit, {
-        exceptions: [EOFError],
+        exceptions: [EOFError, Net::ReadTimeout],
       })
     end
 

--- a/app/services/eth/get_pending_txs.rb
+++ b/app/services/eth/get_pending_txs.rb
@@ -6,9 +6,18 @@ module Eth
     promises :remote_txs
 
     executed do |c|
-      c.remote_txs = c.ethereum_client.
-        txpool_content["result"]["pending"].
-        values.map(&:values).flatten
+      c.remote_txs = geth_circuit.run do
+        c.ethereum_client.txpool_content["result"]["pending"].
+          values.map(&:values).flatten
+      end
+
+      c.fail_and_return! "Unable to fetch txpool content" if c.remote_txs.nil?
+    end
+
+    def self.geth_circuit
+      Circuitbox.circuit(:geth_circuit, {
+        exceptions: [EOFError],
+      })
     end
 
   end

--- a/spec/services/eth/get_pending_txs_spec.rb
+++ b/spec/services/eth/get_pending_txs_spec.rb
@@ -15,5 +15,16 @@ module Eth
       expect(remote_txs.first["blockHash"].to_i(16)).to be_zero
     end
 
+    context "EOFError is raised" do
+      it "fails and stops processing" do
+        expect(client).to receive(:txpool_content).and_raise(EOFError)
+
+        result = described_class.execute(remote_txs: [], ethereum_client: client)
+
+        expect(result).to be_failure
+        expect(result).to be_stop_processing
+      end
+    end
+
   end
 end


### PR DESCRIPTION
- capture `EOFError`
- capture `Net::ReadTimeout`

The issue is intermittent, and it seems like for the `EOFError`, it is somewhere deep in `Net::HTTP`.