### PR TITLE
Adjust job lock and expiry time settings

### DIFF
--- a/app/jobs/check_txs_job.rb
+++ b/app/jobs/check_txs_job.rb
@@ -1,6 +1,10 @@
 class CheckTxsJob < ApplicationJob
 
-  sidekiq_options unique: :until_executed, on_conflict: :log
+  sidekiq_options(
+    unique: :until_executed,
+    on_conflict: :log,
+    lock_expiration: 1.minutes,
+  )
 
   def perform(coin)
     coin.classify.constantize.const_get("CheckTxs").()

--- a/app/jobs/sync_missing_blocks_job.rb
+++ b/app/jobs/sync_missing_blocks_job.rb
@@ -1,7 +1,5 @@
 class SyncMissingBlocksJob < ApplicationJob
 
-  sidekiq_options unique: :until_executed, on_conflict: :log
-
   def perform(coin)
     SyncMissingBlocks.(coin)
   end

--- a/app/jobs/sync_unconfirmed_txs_job.rb
+++ b/app/jobs/sync_unconfirmed_txs_job.rb
@@ -1,6 +1,10 @@
 class SyncUnconfirmedTxsJob < ApplicationJob
 
-  sidekiq_options unique: :until_executed, on_conflict: :log
+  sidekiq_options(
+    unique: :until_executed,
+    on_conflict: :log,
+    lock_expiration: 1.minutes,
+  )
 
   def perform(coin)
     coin.classify.constantize.const_get("SyncUnconfirmedTxs").()

--- a/spec/jobs/check_txs_job_spec.rb
+++ b/spec/jobs/check_txs_job_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe CheckTxsJob do
     expect(described_class.sidekiq_options["on_conflict"]).to eq :log
   end
 
+  it "expires the lock automatically" do
+    expect(described_class.sidekiq_options["lock_expiration"]).
+      to eq 1.minutes
+  end
+
   %w(btc eth).each do |coin|
     # NOTE: not all Block::COINS are synced, yet
     context "given the arg #{coin}" do

--- a/spec/jobs/sync_missing_blocks_job_spec.rb
+++ b/spec/jobs/sync_missing_blocks_job_spec.rb
@@ -6,14 +6,6 @@ RSpec.describe SyncMissingBlocksJob do
     expect(described_class < ApplicationJob).to be true
   end
 
-  it "is unique until_executed" do
-    expect(described_class.sidekiq_options["unique"]).to eq :until_executed
-  end
-
-  it "logs on conflict" do
-    expect(described_class.sidekiq_options["on_conflict"]).to eq :log
-  end
-
   %w(btc eth).each do |coin|
     # NOTE: not all Block::COINS are synced, yet
     context "given the arg `#{coin}`" do

--- a/spec/jobs/sync_unconfirmed_txs_job_spec.rb
+++ b/spec/jobs/sync_unconfirmed_txs_job_spec.rb
@@ -14,6 +14,11 @@ require 'rails_helper'
       expect(described_class.sidekiq_options["on_conflict"]).to eq :log
     end
 
+    it "expires the lock automatically" do
+      expect(described_class.sidekiq_options["lock_expiration"]).
+        to eq 1.minutes
+    end
+
     # Not all coins in Block::COINS are synced, yet
     %w(btc eth).each do |coin|
       context "given arg of #{coin}" do


### PR DESCRIPTION
See https://github.com/mhenrixon/sidekiq-unique-jobs/issues/353

Even with the upgrade to 6.0.7, some jobs still get stuck forever.
Since we know the max amount of time certain jobs can take, let's
set an auto expiration time more than the max time. Having it auto
expire will save us from manually deleting the unique digests that
stay longer than they should, but keeping the lock will allow us to
queue jobs more often without duplicating the jobs queued.

Worst case is that we'll wait one minute to check for new txs,
best case is that we will check every 10 seconds.