### PR TITLE
Revert "Double-check that the blocks being synced are less than max confs"

### DIFF
--- a/app/services/btc/enqueue_block_hashes_to_sync.rb
+++ b/app/services/btc/enqueue_block_hashes_to_sync.rb
@@ -4,7 +4,7 @@ module Btc
     extend LightService::Action
     expects :block_hashes
     SLICE =
-      (ENV["BTC_BLOCK_SYNC_SLICE_SIZE"].presence || SetBlocks::MAX_CONFS)
+      (ENV["BTC_BLOCK_SYNC_SLICE_SIZE"].presence || GetBlocksToSync::MAX_CONFS)
       .to_i.freeze
 
     executed do |c|

--- a/app/services/btc/get_blocks_to_sync.rb
+++ b/app/services/btc/get_blocks_to_sync.rb
@@ -1,12 +1,15 @@
 module Btc
   class GetBlocksToSync
 
+    MAX_CONFS = 10
     extend LightService::Action
     expects :blocks, :current_block_number
     promises :unsynced_blocks
 
     executed do |c|
-      insufficiently_confirmed_blocks = c.blocks.order(height: :asc)
+      insufficiently_confirmed_blocks = c.blocks.
+        with_confirmations_less_than(MAX_CONFS).
+        order(height: :asc)
 
       if block = insufficiently_confirmed_blocks.first
         c.unsynced_blocks = Array(block.height..c.current_block_number)

--- a/app/services/btc/set_blocks.rb
+++ b/app/services/btc/set_blocks.rb
@@ -1,12 +1,11 @@
 module Btc
   class SetBlocks
 
-    MAX_CONFS = 10
     extend LightService::Action
     promises :blocks
 
     executed do |c|
-      c.blocks = Block.btc.with_confirmations_less_than(MAX_CONFS)
+      c.blocks = Block.btc
     end
 
   end

--- a/app/services/eth/get_blocks_to_sync.rb
+++ b/app/services/eth/get_blocks_to_sync.rb
@@ -1,12 +1,14 @@
 module Eth
   class GetBlocksToSync
 
+    MAX_CONFS = 150
     extend LightService::Action
     expects :blocks, :current_block_number
     promises :unsynced_blocks
 
     executed do |c|
       block_heights_with_insufficient_confirmations = c.blocks.
+        with_confirmations_less_than(MAX_CONFS).
         order(height: :asc)
       earliest_insufficiently_confirmed_block =
         block_heights_with_insufficient_confirmations.first

--- a/app/services/eth/set_blocks.rb
+++ b/app/services/eth/set_blocks.rb
@@ -1,12 +1,11 @@
 module Eth
   class SetBlocks
 
-    MAX_CONFS = 150
     extend LightService::Action
     promises :blocks
 
     executed do |c|
-      c.blocks = Block.eth.with_confirmations_less_than(MAX_CONFS)
+      c.blocks = Block.eth
     end
 
   end

--- a/app/services/sync_missing_blocks.rb
+++ b/app/services/sync_missing_blocks.rb
@@ -13,7 +13,7 @@ class SyncMissingBlocks
     when "btc"
       [
         InitBitcoinerClient,
-        execute(->(c) {c[:blocks] = Block.btc}),
+        Btc::SetBlocks,
         DetectBlockGaps,
         Btc::GetBlocksHashes,
         Btc::GetRemoteBlocks,
@@ -26,7 +26,7 @@ class SyncMissingBlocks
       ]
     when "eth"
       [
-        execute(->(c) {c[:blocks] = Block.eth}),
+        Eth::SetBlocks,
         DetectBlockGaps,
         iterate(:unsynced_blocks, [
           Eth::EnqueueSyncBlockJob,

--- a/spec/services/btc/enqueue_block_hashes_to_sync_spec.rb
+++ b/spec/services/btc/enqueue_block_hashes_to_sync_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module Btc
   RSpec.describe EnqueueBlockHashesToSync do
 
-    let(:block_hashes_count) { SetBlocks::MAX_CONFS + 1 }
+    let(:block_hashes_count) { GetBlocksToSync::MAX_CONFS + 1 }
     let(:block_hashes) { block_hashes_count.times.map { |n| "h#{n}" } }
 
     it "enqueues block hashes in blocks of #{described_class::SLICE}" do

--- a/spec/services/btc/get_blocks_to_sync_spec.rb
+++ b/spec/services/btc/get_blocks_to_sync_spec.rb
@@ -26,7 +26,11 @@ module Btc
       subject { resulting_ctx.unsynced_blocks }
 
       before do
-        create(:block, coin: "btc", height: 20)
+        create(:block, {
+          coin: "btc",
+          height: 20,
+          confirmations: described_class::MAX_CONFS,
+        })
       end
 
       it "is an array of unknown blocks up to the current_block_number" do
@@ -45,10 +49,26 @@ module Btc
       subject { resulting_ctx.unsynced_blocks }
 
       before do
-        create(:block, coin: "eth", height: 22)
-        create(:block, coin: "btc", height: 20)
-        create(:block, coin: "btc", height: 21)
-        create(:block, coin: "btc", height: 22)
+        create(:block, {
+          coin: "eth",
+          height: 22,
+          confirmations: described_class::MAX_CONFS,
+        })
+        create(:block, {
+          coin: "btc",
+          height: 20,
+          confirmations: described_class::MAX_CONFS - 1,
+        })
+        create(:block, {
+          coin: "btc",
+          height: 21,
+          confirmations: described_class::MAX_CONFS - 2,
+        })
+        create(:block, {
+          coin: "btc",
+          height: 22,
+          confirmations: described_class::MAX_CONFS,
+        })
       end
 
       it "is an array from earliest block with insufficient confs up to the current_block_number" do

--- a/spec/services/btc/set_blocks_spec.rb
+++ b/spec/services/btc/set_blocks_spec.rb
@@ -5,9 +5,7 @@ module Btc
 
     it "sets blocks to btc blocks" do
       resulting_ctx = described_class.execute
-      expected_sql = Block.btc.
-        with_confirmations_less_than(described_class::MAX_CONFS).to_sql
-      expect(resulting_ctx.blocks.to_sql).to eq expected_sql
+      expect(resulting_ctx.blocks.to_sql).to eq Block.btc.to_sql
     end
 
   end

--- a/spec/services/eth/get_blocks_to_sync_spec.rb
+++ b/spec/services/eth/get_blocks_to_sync_spec.rb
@@ -5,13 +5,25 @@ module Eth
 
     context "there are known ethereum txs" do
       let!(:block_eth_2) do
-        create(:block, coin: "eth", height: 2)
+        create(:block, {
+          coin: "eth",
+          height: 2,
+          confirmations: described_class::MAX_CONFS,
+        })
       end
       let!(:block_eth_3) do
-        create(:block, coin: "eth", height: 3)
+        create(:block, {
+          coin: "eth",
+          height: 3,
+          confirmations: described_class::MAX_CONFS-1,
+        })
       end
       let!(:block_eth_5) do
-        create(:block, coin: "eth", height: 5)
+        create(:block, {
+          coin: "eth",
+          height: 5,
+          confirmations: described_class::MAX_CONFS-1,
+        })
       end
 
       it "sets unsynced_blocks to include earliest insufficiently confirmed block until the current block number" do
@@ -19,7 +31,7 @@ module Eth
           current_block_number: 7,
           blocks: Block.eth,
         )
-        expected_unsynced_blocks = 2..7
+        expected_unsynced_blocks = 3..7
         expect(resulting_ctx.unsynced_blocks).
           to match_array(expected_unsynced_blocks)
       end

--- a/spec/services/eth/set_blocks_spec.rb
+++ b/spec/services/eth/set_blocks_spec.rb
@@ -5,9 +5,7 @@ module Eth
 
     it "sets blocks to eth blocks" do
       resulting_ctx = described_class.execute
-      expected_sql = Block.eth.
-        with_confirmations_less_than(described_class::MAX_CONFS).to_sql
-      expect(resulting_ctx.blocks.to_sql).to eq expected_sql
+      expect(resulting_ctx.blocks.to_sql).to eq Block.eth.to_sql
     end
 
   end


### PR DESCRIPTION
Reverts bloom-solutions/crypto-cold-store#102

This breaks creation of blocks that haven't been seen before.