### PR TITLE
Only unconfirmed

### DIFF
--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -14,6 +14,11 @@ class Block < ApplicationRecord
     where(confirmations.lt(n))
   end
 
+  scope :with_confirmations_greater_than_or_equal_to, ->(n) do
+    confirmations = arel_table[:confirmations]
+    where(confirmations.gteq(n))
+  end
+
   scope :with_height_greater_than_or_equal_to, ->(height) do
     where(arel_table[:height].gteq(height))
   end

--- a/app/services/btc/filter_block_hashes.rb
+++ b/app/services/btc/filter_block_hashes.rb
@@ -1,0 +1,20 @@
+module Btc
+  class FilterBlockHashes
+
+    extend LightService::Action
+    expects :blocks, :block_hashes
+    promises :block_hashes
+
+    executed do |c|
+      sufficiently_confirmed_blocks = c.blocks.
+        with_confirmations_greater_than_or_equal_to(GetBlocksToSync::MAX_CONFS)
+      sufficiently_confirmed_block_hashes = sufficiently_confirmed_blocks.
+        pluck(:block_hash)
+
+      c.block_hashes = c.block_hashes.reject do |block_hash|
+        sufficiently_confirmed_block_hashes.include?(block_hash)
+      end
+    end
+
+  end
+end

--- a/app/services/btc/sync_blocks.rb
+++ b/app/services/btc/sync_blocks.rb
@@ -11,6 +11,7 @@ module Btc
       [
         InitBitcoinerClient,
         SetBlocks,
+        FilterBlockHashes,
         GetRemoteBlocks,
         iterate(:remote_blocks, [
           DeleteForkedBlock,

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -25,6 +25,21 @@ RSpec.describe Block do
     end
   end
 
+  describe ".with_confirmations_greater_than_or_equal_to" do
+    let!(:block_1) { create(:block, confirmations: 11) }
+    let!(:block_2) { create(:block, confirmations: 10) }
+    let!(:block_3) { create(:block, confirmations: 9) }
+
+    it "returns blocks with confirmations less than the given number" do
+      expect(described_class.with_confirmations_greater_than_or_equal_to(12)).
+        to be_empty
+      expect(described_class.with_confirmations_greater_than_or_equal_to(11)).
+        to match_array([block_1])
+      expect(described_class.with_confirmations_greater_than_or_equal_to(10)).
+        to match_array([block_1, block_2])
+    end
+  end
+
   describe ".with_height_greater_than_or_equal_to" do
     let!(:block_1) { create(:block, height: 12) }
     let!(:block_2) { create(:block, height: 11) }

--- a/spec/services/btc/filter_block_hashes_spec.rb
+++ b/spec/services/btc/filter_block_hashes_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+module Btc
+  RSpec.describe FilterBlockHashes do
+
+    it "removes the block_hashes whose blocks have been sufficiently confirmed" do
+      create(:block, coin: "btc", block_hash: "h1", confirmations: 3)
+      create(:block, {
+        coin: "btc",
+        block_hash: "h2",
+        confirmations: GetBlocksToSync::MAX_CONFS,
+      })
+      create(:block, {
+        coin: "btc",
+        block_hash: "h3",
+        confirmations: GetBlocksToSync::MAX_CONFS+1,
+      })
+      create(:block, coin: "btc", block_hash: "h4", confirmations: 1)
+
+      result = described_class.execute(
+        blocks: Block.btc,
+        block_hashes: %w(h1 h2 h3 h4),
+      )
+
+      expect(result.block_hashes).to match_array(%w(h1 h4))
+    end
+
+    it "does not remove the block_hashes whose blocks don't exist" do
+      result = described_class.execute(blocks: Block.btc, block_hashes: %w(h1))
+      expect(result.block_hashes).to eq %w(h1)
+    end
+
+  end
+end


### PR DESCRIPTION
In case the jobs are backed up and multiple jobs a job with a recently-synced block had already been enqueued, this will skip it when it is time to sync