### PR TITLE
Do not sync Eth blocks that have been sufficiently confirmed

### DIFF
--- a/app/services/eth/check_confirmations.rb
+++ b/app/services/eth/check_confirmations.rb
@@ -1,0 +1,14 @@
+module Eth
+  class CheckConfirmations
+
+    extend LightService::Action
+    expects :blocks, :block_height
+
+    executed do |c|
+      block = c.blocks.find_by(height: c.block_height)
+      next c if block.nil? || block.confirmations < GetBlocksToSync::MAX_CONFS
+      c.skip_remaining!
+    end
+
+  end
+end

--- a/app/services/eth/sync_block.rb
+++ b/app/services/eth/sync_block.rb
@@ -11,6 +11,7 @@ module Eth
       [
         InitEthereumClient,
         SetBlocks,
+        CheckConfirmations,
         GetCurrentBlock,
         GetRemoteBlock,
         DeleteForkedBlock,

--- a/spec/services/eth/check_confirmations_spec.rb
+++ b/spec/services/eth/check_confirmations_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+module Eth
+  RSpec.describe CheckConfirmations do
+
+    context "block is sufficiently confirmed" do
+      let!(:block) do
+        create(:block, {
+          coin: "eth",
+          height: 212,
+          confirmations: GetBlocksToSync::MAX_CONFS,
+        })
+      end
+
+      it "skips the rest of the actions" do
+        result = described_class.execute(blocks: Block.eth, block_height: 212)
+        expect(result).to be_success
+        expect(result).to be_skip_remaining
+      end
+    end
+
+    context "block is not sufficiently confirmed" do
+      let!(:block) do
+        create(:block, {
+          coin: "eth",
+          height: 212,
+          confirmations: GetBlocksToSync::MAX_CONFS-1,
+        })
+      end
+
+      it "does nothing" do
+        result = described_class.execute(blocks: Block.eth, block_height: 212)
+        expect(result).to be_success
+        expect(result).to_not be_skip_remaining
+      end
+    end
+
+    context "block does not exist" do
+      it "does nothing" do
+        result = described_class.execute(blocks: Block.eth, block_height: 212)
+        expect(result).to be_success
+        expect(result).to_not be_skip_remaining
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
In cases where the jobs get backed up, this will skip jobs whose blocks have already been sufficiently confirmed thus speeding up the process