### PR TITLE
Expire btc eth jobs

### DIFF
--- a/app/jobs/btc/sync_blocks_job.rb
+++ b/app/jobs/btc/sync_blocks_job.rb
@@ -1,7 +1,11 @@
 module Btc
   class SyncBlocksJob < ApplicationJob
 
-    sidekiq_options unique: :until_executed, on_conflict: :log, queue: "btc"
+    sidekiq_options({
+      unique: :until_executed,
+      queue: "btc",
+      lock_expiration: 2.minutes,
+    })
 
     def perform(block_hashes)
       SyncBlocks.(block_hashes)

--- a/app/jobs/check_txs_job.rb
+++ b/app/jobs/check_txs_job.rb
@@ -3,7 +3,7 @@ class CheckTxsJob < ApplicationJob
   sidekiq_options(
     unique: :until_executed,
     on_conflict: :log,
-    lock_expiration: 1.minutes,
+    lock_expiration: 2.minutes,
   )
 
   def perform(coin)

--- a/app/jobs/eth/sync_block_job.rb
+++ b/app/jobs/eth/sync_block_job.rb
@@ -1,7 +1,11 @@
 module Eth
   class SyncBlockJob < ApplicationJob
 
-    sidekiq_options unique: :until_executed, queue: "eth"
+    sidekiq_options({
+      unique: :until_executed,
+      queue: "eth",
+      lock_expiration: 2.minutes,
+    })
 
     def perform(block_height)
       SyncBlock.(block_height)

--- a/app/services/btc/filter_block_hashes.rb
+++ b/app/services/btc/filter_block_hashes.rb
@@ -11,9 +11,7 @@ module Btc
       sufficiently_confirmed_block_hashes = sufficiently_confirmed_blocks.
         pluck(:block_hash)
 
-      c.block_hashes = c.block_hashes.reject do |block_hash|
-        sufficiently_confirmed_block_hashes.include?(block_hash)
-      end
+      c.block_hashes = c.block_hashes - sufficiently_confirmed_block_hashes
     end
 
   end

--- a/spec/jobs/btc/sync_blocks_job_spec.rb
+++ b/spec/jobs/btc/sync_blocks_job_spec.rb
@@ -11,8 +11,8 @@ module Btc
       expect(described_class.sidekiq_options["unique"]).to eq :until_executed
     end
 
-    it "logs on conflict" do
-      expect(described_class.sidekiq_options["on_conflict"]).to eq :log
+    it "expires the lock" do
+      expect(described_class.sidekiq_options["lock_expiration"]).to eq 2.minutes
     end
 
     it "delegates work to SyncBlocks" do

--- a/spec/jobs/check_txs_job_spec.rb
+++ b/spec/jobs/check_txs_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CheckTxsJob do
 
   it "expires the lock automatically" do
     expect(described_class.sidekiq_options["lock_expiration"]).
-      to eq 1.minutes
+      to eq 2.minutes
   end
 
   %w(btc eth).each do |coin|

--- a/spec/jobs/eth/sync_block_job_spec.rb
+++ b/spec/jobs/eth/sync_block_job_spec.rb
@@ -11,6 +11,10 @@ module Eth
       expect(described_class.sidekiq_options["unique"]).to eq :until_executed
     end
 
+    it "expires the lock" do
+      expect(described_class.sidekiq_options["lock_expiration"]).to eq 2.minutes
+    end
+
     it "delegates work to #{Eth::SyncBlock}" do
       expect(Eth::SyncBlock).to receive(:call).with(4)
       described_class.new.perform(4)


### PR DESCRIPTION
Forgot to add force expiration of locks for `Eth` and `Btc` `SyncBlocksJob`

Also: lengthen forced lock expiration for CheckTxsJob