### PR TITLE
chore: increase lock time expiration for SyncUnconfirmedTxsJob

### DIFF
--- a/app/jobs/sync_unconfirmed_txs_job.rb
+++ b/app/jobs/sync_unconfirmed_txs_job.rb
@@ -3,7 +3,7 @@ class SyncUnconfirmedTxsJob < ApplicationJob
   sidekiq_options(
     unique: :until_executed,
     on_conflict: :log,
-    lock_expiration: 1.minutes,
+    lock_expiration: 2.minutes,
   )
 
   def perform(coin)


### PR DESCRIPTION
They end up piling up, even if they shouldn't take more than 1 minute.